### PR TITLE
fix: allowed-toolsオプションを設定

### DIFF
--- a/src/dot_claude/commands/apply-git.md
+++ b/src/dot_claude/commands/apply-git.md
@@ -1,5 +1,5 @@
 ---
-allow-tools: Bash(git switch main), Bash(git pull)
+allowed-tools: Bash(git switch main), Bash(git pull), Bash(git push)
 description: "Create and auto-merge PR."
 ---
 


### PR DESCRIPTION
## 概要
`/apply-git`コマンドにallowed-toolsオプションを設定しました。

## 変更内容
- `src/dot_claude/commands/apply-git.md`: allowed-toolsに必要なツールを明示的に指定

## 理由
必要なツールを明示的に指定することで、コマンド実行時にツールが利用可能であることを保証します。

🤖 Claude Codeで生成