### PR TITLE
fix: gh pr listとmergeコマンドを許可

### DIFF
--- a/src/dot_claude/commands/apply-git.md
+++ b/src/dot_claude/commands/apply-git.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(git switch main), Bash(git pull), Bash(git push)
+allowed-tools: Bash(git switch main), Bash(git pull), Bash(git push), Bash(gh pr list:*), Bash(gh pr merge:*)
 description: "Create and auto-merge PR."
 ---
 


### PR DESCRIPTION
## 概要
`/apply-git`コマンドのallowed-toolsに`gh pr list`と`gh pr merge`コマンドを追加しました。

## 変更内容
- `src/dot_claude/commands/apply-git.md`: allowed-toolsオプションを更新

## 理由
既存のPRが存在するかを確認し、適切にマージを実行するために、これらのghコマンドが必要です。

🤖 Claude Codeで生成