### PR TITLE
feat: add mise tasks for jj workflow automation

### DIFF
--- a/src/dot_claude/commands/jj-commit.md
+++ b/src/dot_claude/commands/jj-commit.md
@@ -8,7 +8,6 @@ description: "Commit current changes with jj using an appropriate commit message
 Look at the current working copy changes with `jj diff` and create a single commit with an appropriate message.
 
 1. Run `jj diff` to understand what changed
-2. If multiple files are changed, ask the user: "複数のファイルが変更されています。`/jj-split-commit` でファイルごとに分割してコミットしますか？それともこのまままとめてコミットしますか？"
-   - If the user wants to split, stop here and let them run `/jj-split-commit` instead
+2. If multiple files are changed, output "複数のファイルが変更されています。`jj:split-commit` を実行してください。" and stop immediately without committing
 3. Craft a concise commit message following [Conventional Commits](https://www.conventionalcommits.org/) format (e.g. `feat:`, `fix:`, `chore:`, etc.)
 4. Run `jj commit -m '<message>'`

--- a/src/dot_config/mise/tasks/jj/executable_commit.sh
+++ b/src/dot_config/mise/tasks/jj/executable_commit.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#MISE description="Commit current changes with an AI-generated message"
+#MISE dir="{{cwd}}"
+
+set -euo pipefail
+
+claude -p '/jj-commit'

--- a/src/dot_config/mise/tasks/jj/executable_create-pr.sh
+++ b/src/dot_config/mise/tasks/jj/executable_create-pr.sh
@@ -12,14 +12,17 @@ fi
 
 diff=$(jj diff --from main --to @-)
 
+# 既存 PR の存在確認
+current=$(gh pr view "$bookmark" --json title,body 2>/dev/null) || current=""
+
 json=$(echo "$diff" | claude -p 'Based on this diff, respond with ONLY a JSON object (no markdown, no extra text):
-{"title": "concise PR title in conventional commits style", "body": "PR description explaining what was changed and why"}')
+{"title": "concise PR title in conventional commits style", "body": "PR description explaining what was changed and why"}' | grep -v '^```')
 
 title=$(echo "$json" | jq -r '.title')
 body=$(echo "$json" | jq -r '.body')
 
 # PR が既に存在する場合は更新、なければ新規作成
-if gh pr view "$bookmark" > /dev/null 2>&1; then
+if [ -n "$current" ]; then
   gh pr edit "$bookmark" --title "$title" --body "$body"
 else
   gh pr create --base main --head "$bookmark" --title "$title" --body "$body"

--- a/src/dot_config/mise/tasks/jj/executable_create-pr.sh
+++ b/src/dot_config/mise/tasks/jj/executable_create-pr.sh
@@ -4,7 +4,12 @@
 
 set -euo pipefail
 
-bookmark=$(jj bookmark list -r @- | awk -F: '{print $1}')
+bookmark=$(jj bookmark list -r @- | awk -F: '{print $1}' | grep -v '^main$')
+if [ -z "$bookmark" ]; then
+  echo '最新のコミットに bookmark がありません。先に jj:push を実行してください。'
+  exit 1
+fi
+
 diff=$(jj diff --from main --to @-)
 
 json=$(echo "$diff" | claude -p 'Based on this diff, respond with ONLY a JSON object (no markdown, no extra text):
@@ -14,8 +19,8 @@ title=$(echo "$json" | jq -r '.title')
 body=$(echo "$json" | jq -r '.body')
 
 # PR が既に存在する場合は更新、なければ新規作成
-if gh pr view --head "$bookmark" > /dev/null 2>&1; then
-  gh pr edit --head "$bookmark" --title "$title" --body "$body"
+if gh pr view "$bookmark" > /dev/null 2>&1; then
+  gh pr edit "$bookmark" --title "$title" --body "$body"
 else
   gh pr create --base main --head "$bookmark" --title "$title" --body "$body"
 fi

--- a/src/dot_config/mise/tasks/jj/executable_create-pr.sh
+++ b/src/dot_config/mise/tasks/jj/executable_create-pr.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#MISE description="Create a pull request for the previous commit"
+#MISE description="Create or update a pull request for the previous commit"
 #MISE dir="{{cwd}}"
 
 set -euo pipefail
@@ -13,4 +13,9 @@ json=$(echo "$diff" | claude -p 'Based on this diff, respond with ONLY a JSON ob
 title=$(echo "$json" | jq -r '.title')
 body=$(echo "$json" | jq -r '.body')
 
-gh pr create --base main --head "$bookmark" --title "$title" --body "$body"
+# PR が既に存在する場合は更新、なければ新規作成
+if gh pr view --head "$bookmark" > /dev/null 2>&1; then
+  gh pr edit --head "$bookmark" --title "$title" --body "$body"
+else
+  gh pr create --base main --head "$bookmark" --title "$title" --body "$body"
+fi

--- a/src/dot_config/mise/tasks/jj/executable_merge-pr-and-rebase.sh
+++ b/src/dot_config/mise/tasks/jj/executable_merge-pr-and-rebase.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#MISE description="Merge the pull request and rebase onto main"
+#MISE dir="{{cwd}}"
+
+set -euo pipefail
+
+mise run jj:merge-pr
+mise run jj:rebase

--- a/src/dot_config/mise/tasks/jj/executable_merge-pr.sh
+++ b/src/dot_config/mise/tasks/jj/executable_merge-pr.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#MISE description="Merge the pull request for the previous commit"
+#MISE dir="{{cwd}}"
+
+set -euo pipefail
+
+bookmark=$(jj bookmark list -r @- | awk -F: '{print $1}' | grep -v '^main$')
+
+if [ -z "$bookmark" ]; then
+  echo '最新のコミットに bookmark がありません。先に jj:push を実行してください。'
+  exit 1
+elif ! gh pr view "$bookmark" > /dev/null 2>&1; then
+  echo 'PR が見つかりません。先に jj:create-pr を実行してください。'
+  exit 1
+fi
+
+gh pr merge "$bookmark" --merge

--- a/src/dot_config/mise/tasks/jj/executable_pr-create.sh
+++ b/src/dot_config/mise/tasks/jj/executable_pr-create.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 #MISE description="Create a pull request for the previous commit"
+#MISE dir="{{cwd}}"
 
 set -euo pipefail
 
-bookmark=$(jj bookmark list -r @- | awk -F: '{print $1}' | xargs)
+bookmark=$(jj bookmark list -r @- | awk -F: '{print $1}')
 diff=$(jj diff --from main --to @-)
 
 json=$(echo "$diff" | claude -p 'Based on this diff, respond with ONLY a JSON object (no markdown, no extra text):

--- a/src/dot_config/mise/tasks/jj/executable_pr-create.sh
+++ b/src/dot_config/mise/tasks/jj/executable_pr-create.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#MISE description="Create a pull request for the previous commit"
+
+set -euo pipefail
+
+bookmark=$(jj bookmark list -r @- | awk -F: '{print $1}' | xargs)
+diff=$(jj diff --from main --to @-)
+
+json=$(echo "$diff" | claude -p 'Based on this diff, respond with ONLY a JSON object (no markdown, no extra text):
+{"title": "concise PR title in conventional commits style", "body": "PR description explaining what was changed and why"}')
+
+title=$(echo "$json" | jq -r '.title')
+body=$(echo "$json" | jq -r '.body')
+
+gh pr create --base main --head "$bookmark" --title "$title" --body "$body"

--- a/src/dot_config/mise/tasks/jj/executable_push-and-create-pr.sh
+++ b/src/dot_config/mise/tasks/jj/executable_push-and-create-pr.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#MISE description="Push the previous commit and create or update a pull request"
+#MISE dir="{{cwd}}"
+
+set -euo pipefail
+
+mise run jj:push || exit 0
+mise run jj:create-pr

--- a/src/dot_config/mise/tasks/jj/executable_push.sh
+++ b/src/dot_config/mise/tasks/jj/executable_push.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#MISE description="Push the previous commit to remote"
+
+set -euo pipefail
+
+jj git push -c @-

--- a/src/dot_config/mise/tasks/jj/executable_push.sh
+++ b/src/dot_config/mise/tasks/jj/executable_push.sh
@@ -10,8 +10,13 @@ bookmark=$(jj bookmark list -r 'main..@-' 2>/dev/null | awk -F: '{print $1}' | h
 # bookmark があれば @- に move して push
 if [ -n "$bookmark" ]; then
   jj bookmark move "$bookmark" --to @-
-  jj git push -b "$bookmark"
+  push_output=$(jj git push -b "$bookmark" 2>&1)
 # bookmark がなければ新規作成して push
 else
-  jj git push -c @-
+  push_output=$(jj git push -c @- 2>&1)
+fi
+
+echo "$push_output"
+if echo "$push_output" | grep -q 'Nothing changed'; then
+  exit 1
 fi

--- a/src/dot_config/mise/tasks/jj/executable_push.sh
+++ b/src/dot_config/mise/tasks/jj/executable_push.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 #MISE description="Push the previous commit to remote"
+#MISE dir="{{cwd}}"
 
 set -euo pipefail
 
-jj git push -c @-
+# main..@- の範囲にある bookmark（複数ありうるので先頭を取得）
+bookmark=$(jj bookmark list -r 'main..@-' 2>/dev/null | awk -F: '{print $1}' | head -1)
+
+# bookmark があれば @- に move して push
+if [ -n "$bookmark" ]; then
+  jj bookmark move "$bookmark" --to @-
+  jj git push -b "$bookmark"
+# bookmark がなければ新規作成して push
+else
+  jj git push -c @-
+fi

--- a/src/dot_config/mise/tasks/jj/executable_rebase.sh
+++ b/src/dot_config/mise/tasks/jj/executable_rebase.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#MISE description="Fetch from remote and rebase onto main"
+
+set -euo pipefail
+
+jj git fetch
+jj rebase -d main

--- a/src/dot_config/mise/tasks/jj/executable_rebase.sh
+++ b/src/dot_config/mise/tasks/jj/executable_rebase.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 #MISE description="Fetch from remote and rebase onto main"
+#MISE dir="{{cwd}}"
 
 set -euo pipefail
 

--- a/src/dot_config/mise/tasks/jj/executable_split-commit.sh
+++ b/src/dot_config/mise/tasks/jj/executable_split-commit.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#MISE description="Split and commit changes with AI-generated messages"
+#MISE dir="{{cwd}}"
+
+set -euo pipefail
+
+claude -p '/jj-split-commit'


### PR DESCRIPTION
Add mise tasks to automate the jj-based development workflow, covering the full lifecycle from committing to merging PRs.

- Add `jj:commit` task that delegates to Claude Code's `/jj-commit` skill
- Add `jj:split-commit` task that delegates to Claude Code's `/jj-split-commit` skill
- Add `jj:push` task that moves or creates a bookmark and pushes to remote
- Add `jj:create-pr` task that generates PR title/body via Claude and creates or updates a GitHub PR
- Add `jj:push-and-create-pr` task combining push and PR creation
- Add `jj:merge-pr` task that merges the PR for the previous commit
- Add `jj:merge-pr-and-rebase` task combining merge and rebase onto main
- Add `jj:rebase` task that fetches from remote and rebases onto main
- Update `jj-commit.md` command: replace interactive split prompt with a direct instruction to stop and tell the user to run `jj:split-commit` manually