### PR TITLE
fix: add ssh-keygen comment update before ssh-add

### DIFF
--- a/src/dot_config/zsh/dot_zshrc.tmpl
+++ b/src/dot_config/zsh/dot_zshrc.tmpl
@@ -47,6 +47,7 @@ if ! env | grep -q container; then
           keyfile=$(mktemp --tmpdir "XXXXXX_${name}")
           printf '%s' "$item" | jq -r '.value' > "$keyfile"
           chmod 600 "$keyfile"
+          ssh-keygen -c -C "${name#KEY__}" -f "$keyfile" <<< "" >/dev/null 2>&1
           ssh-add "$keyfile" > /dev/null 2>&1
           rm -f "$keyfile"
         done


### PR DESCRIPTION
Add `ssh-keygen -c` command to update the SSH key comment with the key name before adding it via `ssh-add`. This ensures the key is identifiable by name in the SSH agent.