### PR TITLE
fix: install.shの修正とhome-manager適用用のmiseタスク追加

### DIFF
--- a/config/mise/tasks/hm/switch.sh
+++ b/config/mise/tasks/hm/switch.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#MISE description="Apply home-manager configuration"
+
+set -euo pipefail
+
+dotfiles_dir="$(cd -P -- "$(dirname -- "$(command -v -- "$0")")/../../../../.." && pwd -P)"
+
+NIX_CONFIG="experimental-features = nix-command flakes" nix run home-manager -- switch --flake "${dotfiles_dir}" -b backup
+find ~ -maxdepth 5 -name "*.backup" -delete 2>/dev/null || true

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773962693,
+        "narHash": "sha256-nf9pgktDE4E2TCavUT1vh3Nd/tfKixL1BK6P32Zp3hI=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "9d3c1d636e7b8ab10f357cd9bee653cd400437de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1773821835,
+        "narHash": "sha256-TJ3lSQtW0E2JrznGVm8hOQGVpXjJyXY2guAxku2O9A4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/home.nix
+++ b/home.nix
@@ -31,6 +31,10 @@
       source = ./config/mise/tasks/git/use-ssh-remote.sh;
       executable = true;
     };
+    ".config/mise/tasks/hm/switch.sh" = {
+      source = ./config/mise/tasks/hm/switch.sh;
+      executable = true;
+    };
     ".config/mise/tasks/jj/commit.sh" = {
       source = ./config/mise/tasks/jj/commit.sh;
       executable = true;

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,8 @@ if ! command -v nix > /dev/null 2>&1; then
 fi
 
 # 2. home-manager 初回適用
-nix run home-manager -- switch --flake "${script_dir}"
+NIX_CONFIG="experimental-features = nix-command flakes" nix run home-manager -- switch --flake "${script_dir}" -b backup
+find ~ -maxdepth 5 -name "*.backup" -delete 2>/dev/null || true
 
 # 3. Claude CLI インストール / 更新
 if command -v claude > /dev/null 2>&1; then


### PR DESCRIPTION
## 概要

- `install.sh` で `nix-command` 実験的機能が無効な環境でも動作するよう `NIX_CONFIG` 環境変数を使用するように修正
- home-manager適用後に生成される `.backup` ファイルを自動削除するように修正
- `mise run hm:switch` で `home-manager switch` を実行できるタスクを追加
- `flake.lock` を追加