### PR TITLE
refactor: mise タスクを hm:switch から dot:apply-changes に変更

### DIFF
--- a/config/mise/tasks/dot/apply-changes.sh
+++ b/config/mise/tasks/dot/apply-changes.sh
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-dotfiles_dir="$(cd -P -- "$(dirname -- "$(command -v -- "$0")")/../../../../.." && pwd -P)"
+dotfiles_dir="${DOTFILES_DIR:-${HOME}/dotfiles}"
 
 NIX_CONFIG="experimental-features = nix-command flakes" nix run home-manager -- switch --flake "${dotfiles_dir}" -b backup
 find ~ -maxdepth 5 -name "*.backup" -delete 2>/dev/null || true

--- a/home.nix
+++ b/home.nix
@@ -31,8 +31,8 @@
       source = ./config/mise/tasks/git/use-ssh-remote.sh;
       executable = true;
     };
-    ".config/mise/tasks/hm/switch.sh" = {
-      source = ./config/mise/tasks/hm/switch.sh;
+    ".config/mise/tasks/dot/apply-changes.sh" = {
+      source = ./config/mise/tasks/dot/apply-changes.sh;
       executable = true;
     };
     ".config/mise/tasks/jj/commit.sh" = {


### PR DESCRIPTION
## 概要

- `hm:switch` タスクを `dot:apply-changes` にリネーム
- タスクファイルを `config/mise/tasks/hm/switch.sh` から `config/mise/tasks/dot/apply-changes.sh` に移動