### PR TITLE
fix: mise実行前にNixプロファイルを読み込む

### DIFF
--- a/config/zsh/.zshrc
+++ b/config/zsh/.zshrc
@@ -18,6 +18,11 @@ fpath=(
   $MISE_TAB_COMP_PATH(N-/)
 )
 
+# Nix
+if [ -e "$HOME/.nix-profile/etc/profile.d/nix.sh" ]; then
+  . "$HOME/.nix-profile/etc/profile.d/nix.sh"
+fi
+
 # Load mise
 eval "$(mise activate zsh)"
 


### PR DESCRIPTION
## 概要

- `.zshrc` で `mise activate zsh` を実行する前に `~/.nix-profile/etc/profile.d/nix.sh` を source するよう修正
- Nix でインストールした `mise` が `~/.nix-profile/bin` に配置されるため、PATH に追加されていない状態では `mise` が見つからず起動に失敗していた

## テスト

- [ ] zsh 起動時にエラーが出ないことを確認
- [ ] `mise` コマンドが使用できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)