### PR TITLE
セットアップ手順の整備

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# dotfiles
+
+## Setup
+
+```sh
+cd
+git clone https://github.com/Lucky3028/dotfiles.git
+./dotfiles/install.sh
+exit
+```

--- a/config/mise/tasks/dot/apply-changes.sh
+++ b/config/mise/tasks/dot/apply-changes.sh
@@ -5,5 +5,8 @@ set -euo pipefail
 
 dotfiles_dir="${DOTFILES_DIR:-${HOME}/dotfiles}"
 
+jj git fetch --remote origin -R "${dotfiles_dir}"
+jj rebase -d main@origin -R "${dotfiles_dir}"
+
 NIX_CONFIG="experimental-features = nix-command flakes" nix run home-manager -- switch --flake "${dotfiles_dir}" -b backup
 find ~ -maxdepth 5 -name "*.backup" -delete 2>/dev/null || true

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 
 script_dir="$(cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P)"
 
+# 0. システムパッケージ更新
+sudo apt update && sudo apt upgrade -y && sudo apt autoremove -y
+
 # 1. Nix インストール
 if ! command -v nix > /dev/null 2>&1; then
   curl -L https://nixos.org/nix/install | sh -s -- --no-daemon
@@ -33,3 +36,13 @@ if command -v claude > /dev/null 2>&1; then
 else
   curl -fsSL https://claude.ai/install.sh | bash
 fi
+
+# 7. Doppler / GitHub CLI 認証
+doppler login
+gh auth login
+
+# 8. git remote を SSH に変更
+git -C "${script_dir}" remote set-url origin git@github.com:Lucky3028/dotfiles.git
+
+# 9. jj 初期化
+jj git init --colocate -R "${script_dir}"


### PR DESCRIPTION
## 概要

- README にセットアップ手順を追加
- `install.sh` にシステムパッケージ更新・Doppler/gh 認証・SSH remote 設定・jj 初期化を追加
- `dot:apply-changes` タスクで home-manager 適用前に jj でリポジトリを同期するよう変更