### PR TITLE
feat: cd-d abbr でdotfilesディレクトリに移動

### DIFF
--- a/config/zabrze/config.toml
+++ b/config/zabrze/config.toml
@@ -119,6 +119,11 @@ name = "cd to root dir on git repo"
 trigger = "cd-gr"
 snippet = "cd $(git rev-parse --show-toplevel)"
 
+[[snippets]]
+name = "cd to dotfiles dir"
+trigger = "cd-d"
+snippet = "cd ~/dotfiles"
+
 ### replacements ###
 
 [[snippets]]


### PR DESCRIPTION
## 概要

- zabrze に `cd-d` → `cd ~/dotfiles` の abbreviation を追加しました。