### PR TITLE
chore/docs: 不要コメント削除とREADMEにシェル再起動の注意書きを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ git clone https://github.com/Lucky3028/dotfiles.git
 ./dotfiles/install.sh
 exit
 ```
+
+> [!NOTE]
+> `install.sh` がデフォルトシェルを zsh に変更しますが、`chsh` の変更は次回ログイン時に反映されます。
+> `exec $SHELL -l` ではなく `exit` でセッションを抜けて再ログインしてください。

--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -23,7 +23,7 @@
     pkgs.fuse
     pkgs.sqlite
     pkgs.openssl
-    # ツール（run_onchange_03〜05 の代替）
+    # ツール
     pkgs.mise
     pkgs.rustup
     pkgs.podman


### PR DESCRIPTION
## 概要

- `modules/packages.nix` の古い `run_onchange` を参照するコメントを削除しました。
- `README.md` にデフォルトシェル変更の反映タイミングについての注意書きを追加しました（`exec $SHELL -l` ではなく `exit` で再ログインが必要な理由）。