### PR TITLE
fix: SSHコンフィグから未サポートのGSSAPIAuthenticationオプションを削除

### DIFF
--- a/ssh/config
+++ b/ssh/config
@@ -2,7 +2,6 @@ Host *
   ForwardAgent yes
   UpdateHostKeys yes
   PreferredAuthentications publickey,keyboard-interactive,password
-  GSSAPIAuthentication no
   ServerAliveInterval 60
   ServerAliveCountMax 5
   TCPKeepAlive yes


### PR DESCRIPTION
## 概要

- `ssh/config` から `GSSAPIAuthentication no` を削除
- このオプションはGSSAPI/KerberosサポートなしでビルドされたOpenSSHクライアントでは認識されないため、警告が発生していた