### PR TITLE
fix: CIワークフローの不具合を修正しRenovate自動更新を設定する

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,6 +10,15 @@
         "# renovate: datasource=(?<datasource>[a-z-]+?) packageName=(?<packageName>[^\\s]+?)\\n(?<depName>[a-z-]+) = \"(?<currentValue>[^\"]+)\""
       ],
       "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update pinact version in pinact workflow",
+      "managerFilePatterns": ["/(^|/)pinact\\.ya?ml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+?) packageName=(?<packageName>[^\\s]+?)\\n\\s+aqua_version: (?<currentValue>[^\\s]+)"
+      ],
+      "versioningTemplate": "semver"
     }
   ],
   "packageRules": [

--- a/.github/workflows/pinact.yaml
+++ b/.github/workflows/pinact.yaml
@@ -16,7 +16,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: aquaproj/aqua-installer@d1fe50798adafd4e5f381a5cee61bde63f28fce1 # v3.1.1
+      - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
         with:
-          aqua_version: v2.45.0
+          # renovate: datasource=github-releases packageName=aquaproj/aqua
+          aqua_version: v2.55.1
       - run: pinact run --check

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -7,6 +7,8 @@ jobs:
   shellcheck:
     name: Run shellcheck
     runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: reviewdog/action-shellcheck@ccaafec0e6d1da9d10f6a97b8ab4a4e8568f7375 # v1.31.0
@@ -18,9 +20,11 @@ jobs:
   shfmt:
     name: Run shfmt
     runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: reviewdog/action-shfmt@1483ee44ba34b714e83b72d06d0a2e5f56ad2db1 # v1.0.4
+      - uses: reviewdog/action-shfmt@d8f080930b9be5847b4f97e9f4122b81a82aaeac # v1.0.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review


### PR DESCRIPTION
## 概要

PR #205のCIが失敗していた問題を修正する。

## 変更内容

- `shellcheck.yaml`: `github-pr-review` レポーター使用に必要な `pull-requests: write` 権限を追加、shfmt actionのSHAを修正
- `pinact.yaml`: `aquaproj/aqua-installer` を v3.1.1 → v4.0.4 に更新、Renovateアノテーションを追加
- `renovate.json5`: pinactバージョンのRenovate自動更新用カスタムマネージャーを追加