### PR TITLE
ci: add secret scanning, shellcheck, pinact workflows and pre-push hook

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,15 +11,6 @@
       ],
       "versioningTemplate": "semver"
     },
-    {
-      "customType": "regex",
-      "description": "Update pinact version in pinact workflow",
-      "managerFilePatterns": ["/(^|/)pinact\\.ya?ml$/"],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-]+?) packageName=(?<packageName>[^\\s]+?)\\n\\s+aqua_version: (?<currentValue>[^\\s]+)"
-      ],
-      "versioningTemplate": "semver"
-    }
   ],
   "packageRules": [
     {

--- a/.github/workflows/pinact.yaml
+++ b/.github/workflows/pinact.yaml
@@ -14,10 +14,15 @@ jobs:
   pinact:
     name: pinact
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
+      - uses: suzuki-shunsuke/pinact-action@cf51507d80d4d6522a07348e3d58790290eaf0b6 # v2.0.0
         with:
-          # renovate: datasource=github-releases packageName=aquaproj/aqua
-          aqua_version: v2.55.1
-      - run: pinact run --check
+          skip_push: "true"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          verify: "true"
+          review: "true"
+          reviewdog_fail_level: warning

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: reviewdog/action-shellcheck@ccaafec0e6d1da9d10f6a97b8ab4a4e8568f7375 # v1.31.0
+      - uses: reviewdog/action-shellcheck@1bb9751763fdfbee4b5043772c37374f103bff9e # v1.31.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review


### PR DESCRIPTION
## Changes

- Add `gitleaks.yaml` workflow for secret scanning on PRs
- Add `shellcheck.yaml` workflow for shell linting (shellcheck + shfmt) via reviewdog
- Add `pinact.yaml` workflow to verify and review GitHub Actions pin integrity
- Add `pre-push` git hook that runs gitleaks on commits before pushing
- Add `gitleaks` and `pinact` tools to mise config
- Add `.gitignore` to exclude nix `result` symlinks
- Reorganize dotfiles under `home/` directory structure
- Update `home.nix` to include new githooks configuration