### PR TITLE
fix: remove pinact custom Renovate manager and add PR permissions to pinact workflow

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,15 +10,6 @@
         "# renovate: datasource=(?<datasource>[a-z-]+?) packageName=(?<packageName>[^\\s]+?)\\n(?<depName>[a-z-]+) = \"(?<currentValue>[^\"]+)\""
       ],
       "versioningTemplate": "semver"
-    },
-    {
-      "customType": "regex",
-      "description": "Update pinact version in pinact workflow",
-      "managerFilePatterns": ["/(^|/)pinact\\.ya?ml$/"],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-]+?) packageName=(?<packageName>[^\\s]+?)\\n\\s+aqua_version: (?<currentValue>[^\\s]+)"
-      ],
-      "versioningTemplate": "semver"
     }
   ],
   "packageRules": [

--- a/.github/workflows/pinact.yaml
+++ b/.github/workflows/pinact.yaml
@@ -14,10 +14,15 @@ jobs:
   pinact:
     name: pinact
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
+      - uses: suzuki-shunsuke/pinact-action@cf51507d80d4d6522a07348e3d58790290eaf0b6 # v2.0.0
         with:
-          # renovate: datasource=github-releases packageName=aquaproj/aqua
-          aqua_version: v2.55.1
-      - run: pinact run --check
+          skip_push: "true"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          verify: "true"
+          review: "true"
+          reviewdog_fail_level: warning


### PR DESCRIPTION
## Changes

- Removed the custom Renovate regex manager for updating the pinact version in the pinact workflow (`.github/renovate.json5`)
- Replaced `aqua-installer` with `pinact-action` in the pinact workflow, which handles pinact execution directly
- Added `permissions` block (`contents: read`, `pull-requests: write`) to the pinact job
- Configured `pinact-action` with `github_token`, `verify`, `review`, and `reviewdog_fail_level` options to enable PR review comments

## Why

The `aqua-installer` step and its associated Renovate custom manager are no longer needed since `pinact-action` handles the tooling setup and execution. Adding `pull-requests: write` permission allows pinact to post review comments on PRs.