### PR TITLE
feat: add Context7 MCP server to Claude settings

### DIFF
--- a/home/claude/settings.json
+++ b/home/claude/settings.json
@@ -68,6 +68,10 @@
   "mcpServers": {
     "github": {
       "command": "github-mcp-server"
+    },
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
     }
   },
   "hooks": {


### PR DESCRIPTION
Add the Context7 MCP server as an HTTP-based MCP server in Claude settings.

This enables access to Context7's MCP endpoint for enhanced context and documentation lookup capabilities.