### PR TITLE
fix: 新規ブランチのpre-pushフックでリモートに存在しないコミットのみスキャンするよう修正

### DIFF
--- a/home/githooks/pre-push
+++ b/home/githooks/pre-push
@@ -9,8 +9,8 @@ while read -r local_ref local_sha remote_ref remote_sha; do
   fi
 
   if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
-    # 新規ブランチ: ローカルの全コミットをスキャン
-    gitleaks git --no-banner --redact --log-opts="$local_sha"
+    # 新規ブランチ: リモートにまだ存在しないコミットのみスキャン
+    gitleaks git --no-banner --redact --log-opts="$local_sha --not --remotes"
   else
     # 既存ブランチ: pushされる差分のみスキャン
     gitleaks git --no-banner --redact --log-opts="$remote_sha..$local_sha"


### PR DESCRIPTION
## Summary
- 新規ブランチのpush時、`gitleaks`がローカルの全コミットをスキャンしていた問題を修正
- `--not --remotes`オプションを追加し、リモートにまだ存在しないコミットのみをスキャン対象とするよう変更

## Test plan
- [ ] 新規ブランチをpushしてgitleaksのスキャンが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)