### PR TITLE
feat: DopplerからBW_SESSIONを読み込み、bw-refresh関数を追加

### DIFF
--- a/home/config/zsh/.zshrc
+++ b/home/config/zsh/.zshrc
@@ -58,6 +58,27 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
           done
     fi
 
+    # Doppler から BW_SESSION を読み込む
+    _bw_session=$(doppler secrets get BW_SESSION --plain --project personal-secrets --config prd 2>/dev/null)
+    if [[ -n "$_bw_session" ]]; then
+      export BW_SESSION="$_bw_session"
+    fi
+    unset _bw_session
+
   fi
+
+  # Bitwarden のセッションを更新して Doppler に保存する
+  bw-refresh() {
+    local session
+    session=$(bw unlock --raw)
+    if [[ -n "$session" ]]; then
+      export BW_SESSION="$session"
+      if doppler secrets set "BW_SESSION=$session" --project personal-secrets --config prd > /dev/null 2>&1; then
+        echo "BW_SESSION saved to Doppler"
+      else
+        echo "Failed to save BW_SESSION to Doppler. Run 'doppler login' and try again." >&2
+      fi
+    fi
+  }
 
 fi


### PR DESCRIPTION
## 概要

- Bitwarden CLIのセッショントークン（`BW_SESSION`）をDoppler（`personal-secrets/prd`）で管理するようにした
- シェル起動時にDopplerから`BW_SESSION`を自動的に読み込んでエクスポートする
- セッションの更新・Dopplerへの保存を行う`bw-refresh`関数を追加した

## 使い方

```sh
# 初回またはセッション期限切れ時
bw-refresh
# → マスターパスワードを入力後、BW_SESSION がDopplerに保存され現在のシェルにも反映される

# 次回以降のシェル起動時は自動でDopplerから読み込まれる
```