### PR TITLE
chore: temporarily disable uv updates (astral-sh/uv#19278)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,6 +16,11 @@
     {
       "matchPackageNames": ["bitwarden/clients"],
       "extractVersion": "^cli-v(?<version>.+)$"
+    },
+    {
+      "description": "uv 0.11.9 のリリースが GitHub Artifact Attestations を欠いているため一時的に無効化 (https://github.com/astral-sh/uv/issues/19278)",
+      "matchPackageNames": ["astral-sh/uv"],
+      "enabled": false
     }
   ]
 }

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777894865,
-        "narHash": "sha256-agINDb/tr4v2uaVmgE/i0dY1M2JJdzUI/Caup/MWEGU=",
+        "lastModified": 1777913624,
+        "narHash": "sha256-4MwfrGuqjsnEORQbM3cmkmG/9cWhDV63dTDguDj4FXw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9c6f1307e1d76a2285d8001e1b8bc281bfe15dac",
+        "rev": "a89686d115e970e200eb2caa7603f3673050e00c",
         "type": "github"
       },
       "original": {

--- a/home/config/mise/config.toml
+++ b/home/config/mise/config.toml
@@ -30,7 +30,7 @@ ripgrep = "15.1.0"
 starship = "1.25.1"
 terraform = "1.15.1"
 usage = "3.3.0"
-uv = "0.11.9"
+uv = "0.11.8"
 yq = "4.53.2"
 # renovate: datasource=github-releases packageName=zellij-org/zellij
 zellij = "0.44.2"


### PR DESCRIPTION
## Summary

- uv 0.11.9 のリリースが GitHub Artifact Attestations を欠いているため、Renovate による uv の自動更新を一時的に無効化します
- https://github.com/astral-sh/uv/issues/19278 の修正リリースが出たら再有効化します