### PR TITLE
ci: speed up yui installation

### DIFF
--- a/.github/workflows/yui-check.yaml
+++ b/.github/workflows/yui-check.yaml
@@ -15,6 +15,9 @@ jobs:
       - name: Install Rust
         run: rustup toolchain install stable --profile minimal
       - name: Install yui
-        run: cargo install yui-cli --locked --version 0.10.0
+        uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
+        with:
+          tool: yui-cli@0.10.0
+          fallback: cargo-binstall
       - name: List managed files
         run: yui list --no-color


### PR DESCRIPTION
## Summary
- install yui-cli 0.10.0 via taiki-e/install-action
- prefer prebuilt releases and fall back to cargo-binstall

## Tests
- YAML parse succeeded
- pinact verification succeeded
- git diff --check succeeded