### PR TITLE
ci: track yui-cli version with Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,6 +10,15 @@
         "# renovate: datasource=(?<datasource>[a-z-]+?) packageName=(?<packageName>[^\\s]+?)\\n(?<depName>[a-z-]+) = \"(?<currentValue>[^\"]+)\""
       ],
       "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update yui-cli in GitHub Actions workflow",
+      "managerFilePatterns": ["/(^|/)\\.github/workflows/yui-check\\.yaml$/"],
+      "matchStrings": [
+        "\\s+# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>[^\\s]+?)\\n\\s+tool: yui-cli@(?<currentValue>[^\\s]+)"
+      ],
+      "versioningTemplate": "cargo"
     }
   ],
   "packageRules": [

--- a/.github/workflows/yui-check.yaml
+++ b/.github/workflows/yui-check.yaml
@@ -17,6 +17,7 @@ jobs:
       - name: Install yui
         uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2.85.10
         with:
+          # renovate: datasource=crate depName=yui-cli
           tool: yui-cli@0.10.0
           fallback: cargo-binstall
       - name: List managed files


### PR DESCRIPTION
## Summary

- add Renovate metadata for yui-cli in the yui check workflow
- configure Renovate to track the yui-cli crate version

## Test

- validated Renovate JSON configuration syntax
- verified the custom manager matches yui-cli@0.10.0