### PR TITLE
feat(codex): enable GitHub network access

### DIFF
--- a/home/.codex/config.toml
+++ b/home/.codex/config.toml
@@ -31,5 +31,11 @@ glob_scan_max_depth = 3
 "**/.npmrc" = "deny"
 "**/*.sock" = "deny"
 
+[permissions.safe-workspace.network]
+enabled = true
+
+[permissions.safe-workspace.network.domains]
+"github.com" = "allow"
+
 [projects."/home/lucky/dotfiles"]
 trust_level = "trusted"


### PR DESCRIPTION
## Summary

- Enable sandbox network access for the Codex safe-workspace profile
- Allow GitHub access for jj push operations

## Validation

- Codex configuration syntax check passed
- DNS resolution for github.com passed
- jj git push completed successfully