### PR TITLE
ci: validate Codex config and GitHub Actions security

### DIFF
--- a/.github/workflows/ghasec.yaml
+++ b/.github/workflows/ghasec.yaml
@@ -1,4 +1,4 @@
-name: pinact
+name: Check GitHub Actions security
 on:
   pull_request:
     branches:
@@ -10,19 +10,19 @@ on:
       - main
     paths:
       - .github/workflows/**
+permissions: {}
 jobs:
-  pinact:
-    name: pinact
+  ghasec:
+    name: Run ghasec
     runs-on: ubuntu-24.04
+    timeout-minutes: 3
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: suzuki-shunsuke/pinact-action@896d595f299e71d65b9d28349d6956abe144390a # v3.0.0
         with:
-          skip_push: "true"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          verify: "true"
-          review: "true"
-          reviewdog_fail_level: warning
+          persist-credentials: false
+      - uses: koki-develop/ghasec-action@2810775d2a300cb3fd9583c36c05b5ee3310c5b8 # v1.1.1
+        with:
+          version: v0.17.0
+          install-shellcheck: true

--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -3,14 +3,20 @@ on:
   pull_request:
     branches:
       - main
+permissions: {}
 jobs:
   gitleaks:
     name: gitleaks
     runs-on: ubuntu-24.04
+    timeout-minutes: 3
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -1,29 +1,21 @@
-name: Lint and format shell files
+name: Format shell files
 on:
   pull_request:
     branches:
       - main
+permissions: {}
 jobs:
-  shellcheck:
-    name: Run shellcheck
-    runs-on: ubuntu-24.04
-    permissions:
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: reviewdog/action-shellcheck@0722bbdb0d47f04c1b53b8734d2422ac63a45ec6 # v1.32.1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          reporter: github-pr-review
-          # warning以上の問題が検出された場合にCIを失敗させる（info のみの場合はCIは成功）
-          fail_level: warning
   shfmt:
     name: Run shfmt
     runs-on: ubuntu-24.04
+    timeout-minutes: 3
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: reviewdog/action-shfmt@c5e3ba7497c338866921924691aef4fa18bc1fe0 # v1.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-codex-rules.yaml
+++ b/.github/workflows/validate-codex-rules.yaml
@@ -1,0 +1,53 @@
+name: Validate Codex configuration
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - home/.codex/config.toml
+      - home/.codex/rules/**
+      - .github/workflows/validate-codex-rules.yaml
+  push:
+    branches:
+      - main
+    paths:
+      - home/.codex/config.toml
+      - home/.codex/rules/**
+      - .github/workflows/validate-codex-rules.yaml
+permissions: {}
+jobs:
+  validate:
+    name: Validate Codex configuration
+    runs-on: ubuntu-24.04
+    timeout-minutes: 3
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install Codex CLI
+        run: npm install --global --no-fund --no-audit @openai/codex@0.147.0
+      - name: Check Codex config
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          codex_config_dir=$(mktemp -d)
+          cp home/.codex/config.toml "$codex_config_dir/config.toml"
+          env CODEX_HOME="$codex_config_dir" \
+            codex --strict-config exec --help >/dev/null
+      - name: Check command decisions
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git_decision=$(codex execpolicy check \
+            --rules home/.codex/rules/default.rules \
+            -- git status | jq -r '.decision')
+          test "$git_decision" = "forbidden"
+
+          jj_decision=$(codex execpolicy check \
+            --rules home/.codex/rules/default.rules \
+            -- jj status | jq -r '.decision // "allow"')
+          test "$jj_decision" != "forbidden"

--- a/.github/workflows/validate-renovate-config.yaml
+++ b/.github/workflows/validate-renovate-config.yaml
@@ -12,11 +12,16 @@ on:
     paths:
       - .github/renovate.json5
       - .github/workflows/validate-renovate-config.yaml
+permissions: {}
 jobs:
   validate:
     name: Validate Renovate config
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: suzuki-shunsuke/github-action-renovate-config-validator@ee9f69e1f683ed0d08225086482b34fc9abe9300 # v2.1.0
-

--- a/.github/workflows/yui-check.yaml
+++ b/.github/workflows/yui-check.yaml
@@ -6,12 +6,18 @@ on:
   push:
     branches:
       - main
+permissions: {}
 jobs:
   yui:
     name: Validate yui configuration
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Install Rust
         run: rustup toolchain install stable --profile minimal
       - name: Install yui

--- a/home/.codex/AGENTS.md
+++ b/home/.codex/AGENTS.md
@@ -9,6 +9,7 @@
 
 - Do not use `git`; use `jj` instead.
 - If `git` is available but `jj` is not, ask the user to initialize the repository with `jj` and obtain confirmation before proceeding.
+- Use Conventional Commits for commit messages.
 
 ## Working Style
 

--- a/home/.codex/rules/default.rules
+++ b/home/.codex/rules/default.rules
@@ -1,0 +1,11 @@
+# Prohibit Git commands; use jj for version control instead.
+prefix_rule(
+    pattern = ["git"],
+    decision = "forbidden",
+    justification = "Use `jj` instead of `git`.",
+    match = [
+        "git status",
+        "git add -A",
+        "git commit -m \"feat: add rule\"",
+    ],
+)

--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -35,12 +35,12 @@ zellij = "0.44.3"
 doppler = { version = "3.76.1", exe = "doppler" }
 # renovate: datasource=github-releases packageName=gitleaks/gitleaks
 "aqua:gitleaks/gitleaks" = "8.30.1"
-# renovate: datasource=github-releases packageName=suzuki-shunsuke/pinact
-"aqua:suzuki-shunsuke/pinact" = "4.1.1"
 "jjui" = "0.10.9"
 "npm:opencode-ai" = { version = "1.18.15", allow_builds = "opencode-ai" }
 "npm:@openai/codex" = "0.147.0"
 kustomize = "5.8.1"
+"go:github.com/koki-develop/ghasec" = "0.17.0"
+shellcheck = "0.11.0"
 
 [hooks]
 postinstall = "$MISE_CONFIG_HOME/hooks/postinstall.sh"


### PR DESCRIPTION
## Summary

- Add CI validation for Codex config.toml and execpolicy rules.
- Replace pinact with ghasec and run ShellCheck through ghasec.
- Keep shellcheck.yaml dedicated to shfmt.
- Harden existing workflows with explicit permissions, timeouts, and credential-free checkout.

## Tests

- ghasec --format github-actions
- YAML parsing with yq
- Codex strict config and execpolicy checks