### PR TITLE
ci: track workflow versions and configure Codex access

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,6 +19,27 @@
         "\\s+# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>[^\\s]+?)\\n\\s+tool: yui-cli@(?<currentValue>[^\\s]+)"
       ],
       "versioningTemplate": "cargo"
+    },
+    {
+      "customType": "regex",
+      "description": "Update ghasec in GitHub Actions workflow",
+      "managerFilePatterns": ["/(^|/)\\.github/workflows/ghasec\\.yaml$/"],
+      "matchStrings": [
+        "\\s+version: (?<currentValue>v[^\\s]+)"
+      ],
+      "depNameTemplate": "koki-develop/ghasec",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update Codex CLI in GitHub Actions workflow",
+      "managerFilePatterns": ["/(^|/)\\.github/workflows/validate-codex-rules\\.yaml$/"],
+      "matchStrings": [
+        "@openai/codex@(?<currentValue>[^\\s]+)"
+      ],
+      "depNameTemplate": "@openai/codex",
+      "datasourceTemplate": "npm"
     }
   ],
   "packageRules": [

--- a/home/.codex/config.toml
+++ b/home/.codex/config.toml
@@ -17,6 +17,11 @@ glob_scan_max_depth = 3
 # These SSH metadata files are readable so yui-managed links can be verified.
 "~/.ssh/config" = "read"
 "~/.ssh/allowed_signers" = "read"
+# Allow npm to use its package cache for CLI-based validation commands.
+"~/.npm/**" = "write"
+# Allow pnpm to use its cache and package store.
+"~/.cache/pnpm/**" = "write"
+"~/.local/share/pnpm/**" = "write"
 
 [permissions.safe-workspace.filesystem.":workspace_roots"]
 ".git/**" = "write"

--- a/home/.codex/config.toml
+++ b/home/.codex/config.toml
@@ -40,7 +40,7 @@ glob_scan_max_depth = 3
 enabled = true
 
 [permissions.safe-workspace.network.domains]
-"github.com" = "allow"
+"*" = "allow"
 
 [projects."/home/lucky/dotfiles"]
 trust_level = "trusted"


### PR DESCRIPTION
## Summary

- Add Renovate custom managers for ghasec and @openai/codex versions in GitHub Actions
- Allow npm and pnpm cache/store access in the safe-workspace profile
- Allow all network domains in the safe-workspace profile

## Validation

- Renovate config validator: passed
- Codex strict config validation: passed
- Working tree: clean