### PR TITLE
refactor: mise のバックエンド指定を整理

### DIFF
--- a/home/.config/mise/config.toml
+++ b/home/.config/mise/config.toml
@@ -1,6 +1,6 @@
 [tools]
-"aqua:rossmacarthur/sheldon" = "0.8.5"
-"aqua:cli/cli" = "2.97.0"
+"github:rossmacarthur/sheldon" = "0.8.5"
+gh = "2.97.0"
 # renovate: datasource=github-releases packageName=sharkdp/bat
 bat = "0.26.1"
 # renovate: datasource=github-releases packageName=bitwarden/clients
@@ -34,7 +34,7 @@ yq = "4.53.3"
 zellij = "0.44.3"
 doppler = { version = "3.76.1", exe = "doppler" }
 # renovate: datasource=github-releases packageName=gitleaks/gitleaks
-"aqua:gitleaks/gitleaks" = "8.30.1"
+gitleaks = "8.30.1"
 "jjui" = "0.10.9"
 "npm:opencode-ai" = { version = "1.18.15", allow_builds = "opencode-ai" }
 "npm:@openai/codex" = "0.147.0"


### PR DESCRIPTION
## 概要

- sheldon を GitHub backend で管理
- GitHub CLI と gitleaks を mise の標準 registry 名に変更
- jj-starship と zabrze は標準 registry にないため cargo backend を維持

## 確認

- mise ls --local