### PR TITLE
fix(codex): separate writable config from dotfiles

### DIFF
--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -19,6 +19,5 @@ jobs:
       - uses: reviewdog/action-shfmt@c5e3ba7497c338866921924691aef4fa18bc1fe0 # v1.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          reporter: github-pr-review
           fail_level: warning
           shfmt_flags: -i 2

--- a/.github/workflows/validate-codex-rules.yaml
+++ b/.github/workflows/validate-codex-rules.yaml
@@ -4,14 +4,14 @@ on:
     branches:
       - main
     paths:
-      - home/.codex/config.toml
+      - home/.codex/dotfiles.config.toml
       - home/.codex/rules/**
       - .github/workflows/validate-codex-rules.yaml
   push:
     branches:
       - main
     paths:
-      - home/.codex/config.toml
+      - home/.codex/dotfiles.config.toml
       - home/.codex/rules/**
       - .github/workflows/validate-codex-rules.yaml
 permissions: {}
@@ -34,9 +34,9 @@ jobs:
           set -euo pipefail
 
           codex_config_dir=$(mktemp -d)
-          cp home/.codex/config.toml "$codex_config_dir/config.toml"
+          cp home/.codex/dotfiles.config.toml "$codex_config_dir/dotfiles.config.toml"
           env CODEX_HOME="$codex_config_dir" \
-            codex --strict-config exec --help >/dev/null
+            codex --strict-config --profile dotfiles exec --help >/dev/null
       - name: Check command decisions
         shell: bash
         run: |

--- a/.github/workflows/validate-codex-rules.yaml
+++ b/.github/workflows/validate-codex-rules.yaml
@@ -33,7 +33,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          codex_config_dir=$(mktemp -d)
+          codex_config_dir=$(mktemp -d "$GITHUB_WORKSPACE/codex-home.XXXXXX")
+          trap 'rm -rf -- "$codex_config_dir"' EXIT
           cp home/.codex/dotfiles.config.toml "$codex_config_dir/dotfiles.config.toml"
           env CODEX_HOME="$codex_config_dir" \
             codex --strict-config --profile dotfiles exec --help >/dev/null

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ configuration files, `apt` for system packages, and `mise` for development
 tools. Configuration files can be edited directly under `$HOME`; yui keeps
 the repository and the live files linked.
 
+Codex's writable `~/.codex/config.toml` is kept local. The shared Codex
+defaults are stored in `~/.codex/dotfiles.config.toml`, and the `codex`
+wrapper applies that profile automatically.
+
 To update an existing installation:
 
 ```sh

--- a/home/.codex/config.toml
+++ b/home/.codex/config.toml
@@ -19,6 +19,15 @@ glob_scan_max_depth = 3
 "~/.ssh/allowed_signers" = "read"
 # Allow npm to use its package cache for CLI-based validation commands.
 "~/.npm/**" = "write"
+# Allow Go to use its build cache.
+"~/.cache/go-build/**" = "write"
+# Allow Go to use its module download cache.
+"~/go/pkg/mod/**" = "write"
+# Allow mise to use its tool-path cache.
+"~/.cache/mise/**" = "write"
+# Allow Cargo to use its package and git caches.
+"~/.cargo/registry/**" = "write"
+"~/.cargo/git/**" = "write"
 # Allow pnpm to use its cache and package store.
 "~/.cache/pnpm/**" = "write"
 "~/.local/share/pnpm/**" = "write"

--- a/home/.codex/dotfiles.config.toml
+++ b/home/.codex/dotfiles.config.toml
@@ -50,6 +50,3 @@ enabled = true
 
 [permissions.safe-workspace.network.domains]
 "*" = "allow"
-
-[projects."/home/lucky/dotfiles"]
-trust_level = "trusted"

--- a/home/.config/zsh/.zshrc
+++ b/home/.config/zsh/.zshrc
@@ -83,3 +83,8 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   }
 
 fi
+
+# Always use the dotfiles wrapper, even if a later shell integration changes PATH.
+codex() {
+  "$HOME/bin/codex" "$@"
+}

--- a/home/bin/codex
+++ b/home/bin/codex
@@ -6,7 +6,7 @@ codex_bin=$(mise which codex)
 
 for arg in "$@"; do
   case "$arg" in
-    --profile|-p|--profile=*|-p?*)
+    --profile | -p | --profile=* | -p?*)
       exec "$codex_bin" "$@"
       ;;
   esac

--- a/home/bin/codex
+++ b/home/bin/codex
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -eu
+
+codex_bin=$(mise which codex)
+
+for arg in "$@"; do
+  case "$arg" in
+    --profile|-p|--profile=*|-p?*)
+      exec "$codex_bin" "$@"
+      ;;
+  esac
+done
+
+exec "$codex_bin" --profile dotfiles "$@"

--- a/home/bin/codex
+++ b/home/bin/codex
@@ -6,9 +6,9 @@ codex_bin=$(mise which codex)
 
 for arg in "$@"; do
   case "$arg" in
-    --profile | -p | --profile=* | -p?*)
-      exec "$codex_bin" "$@"
-      ;;
+  --profile | -p | --profile=* | -p?*)
+    exec "$codex_bin" "$@"
+    ;;
   esac
 done
 

--- a/install.sh
+++ b/install.sh
@@ -47,6 +47,7 @@ install -d -m 700 "$HOME/.ssh"
 # Preserve the executable files that Home Manager used to mark explicitly.
 find "${script_dir}/home" -type f -name '*.sh' -exec chmod +x {} +
 chmod +x "${script_dir}/home/.githooks/pre-push" \
+  "${script_dir}/home/bin/codex" \
   "${script_dir}/home/bin/restore-zsh-history" \
   "${script_dir}/home/bin/toast"
 


### PR DESCRIPTION
## Summary

- separate Codex-managed config.toml from the VCS-managed profile
- launch Codex with the dotfiles profile through a small mise-backed wrapper
- preserve the existing local Codex config and document the setup

## Validation

- shellcheck
- bash/sh syntax checks
- Codex strict config/profile loading
- wrapper smoke tests