### PR TITLE
feat(jj): sign commits with SSH key

### DIFF
--- a/home/.config/jj/config.toml
+++ b/home/.config/jj/config.toml
@@ -3,3 +3,9 @@
 [user]
 name = "Lucky3028"
 email = "24449974+Lucky3028@users.noreply.github.com"
+
+[signing]
+behavior = "own"
+backend = "ssh"
+key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIyOaU2sCb4k6hAHbge9Nr+KAVTH9d0lv80RcL5av5eu"
+backends.ssh.allowed-signers = "~/.ssh/allowed_signers"


### PR DESCRIPTION
## Summary

- Enable SSH-based commit signing in jj
- Configure the allowed signers file

## Test plan

- jj commit signing configuration is isolated in `home/.config/jj/config.toml`