### PR TITLE
feat(ssh): use configured SSH wrapper for Codex

### DIFF
--- a/home/.codex/bin/ssh
+++ b/home/.codex/bin/ssh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /usr/bin/ssh -F "$HOME/.ssh/config" "$@"

--- a/home/bin/codex
+++ b/home/bin/codex
@@ -2,6 +2,9 @@
 
 set -eu
 
+export GIT_SSH_COMMAND='ssh -F /dev/null'
+export PATH="$HOME/.codex/bin:$PATH"
+
 codex_bin=$(mise which codex)
 
 for arg in "$@"; do

--- a/install.sh
+++ b/install.sh
@@ -48,6 +48,7 @@ install -d -m 700 "$HOME/.ssh"
 find "${script_dir}/home" -type f -name '*.sh' -exec chmod +x {} +
 chmod +x "${script_dir}/home/.githooks/pre-push" \
   "${script_dir}/home/bin/codex" \
+  "${script_dir}/home/.codex/bin/ssh" \
   "${script_dir}/home/bin/restore-zsh-history" \
   "${script_dir}/home/bin/toast"
 


### PR DESCRIPTION
## Summary
- Add a Codex SSH wrapper that uses the user SSH config.
- Keep Git SSH commands isolated while exposing the wrapper through PATH.
- Install the wrapper with executable permissions.

## Tests
- `sh -n home/.codex/bin/ssh home/bin/codex install.sh`
- `home/.codex/bin/ssh -o BatchMode=yes -o ConnectTimeout=10 __prd-zbx-01 true`