### PR TITLE
feat: make Bitwarden sessions terminal-local

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,12 +127,16 @@ mise install
 
 WSL では、Linux 側の ssh-agent を TCP 経由で Windows 側から利用できるようにし、`SSH_AUTH_SOCK` を Windows のユーザー環境変数へ設定します。`pwsh.exe` が PATH にない環境ではこの処理は利用できません。
 
-### `~/bin` の補助コマンド
+### `~/bin` の補助コマンドと zsh 関数
+
+`home/bin/functions` には sheldon が現在の zsh に読み込む関数を置きます。`cd` や `export` の結果を呼び出し元のシェルへ反映する必要がある処理はここに置き、独立して実行するコマンドは `home/bin` 直下に置きます。
 
 | コマンド | 役割 |
 | --- | --- |
 | `codex` | `--profile` が指定されていない場合に `dotfiles` プロファイルを使う Codex wrapper |
 | `cd-ghq` | `ghq list` の結果を fzf で選んで移動する zsh 関数 |
+| `login-bitwarden` / `unlock-bitwarden` | Bitwarden CLI のログインと、端末ごとの unlock |
+| `kill-ssh-agent` | WSL 用の ssh-agent 中継を停止する zsh 関数 |
 | `restore-zsh-history` | 壊れた zsh 履歴を `strings` で復旧する |
 | `toast` | WSL から BurntToast を使って Windows 通知を表示する |
 
@@ -183,4 +187,3 @@ push 前にも [`home/.githooks/pre-push`](home/.githooks/pre-push) が gitleaks
 ## ライセンス
 
 このリポジトリの設定・スクリプトは [`MIT License`](LICENSE) の下で公開しています。
-

--- a/home/.config/zsh/.zshrc
+++ b/home/.config/zsh/.zshrc
@@ -56,31 +56,8 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
         rm -f "$keyfile" "${keyfile}.pub"
       done
 
-  # Doppler から BW_SESSION を読み込む
-  _bw_session=$(doppler secrets get BW_SESSION --plain --project personal-secrets --config prd 2>/dev/null)
-  if [[ -n "$_bw_session" ]]; then
-    export BW_SESSION="$_bw_session"
-  fi
-  unset _bw_session
-
-  # ssh-agent を止める
-  kill-ssh-agent() {
-    pkill -f "socat.*TCP-LISTEN:${SSH_AGENT_LISTENING_PORT}"
-  }
-
-  # Bitwarden のログインセッションを更新して Doppler に SSH 鍵を保存し直す
-  refresh-doppler-ssh-key() {
-    local session
-    session=$(bw unlock --raw)
-    if [[ -n "$session" ]]; then
-      export BW_SESSION="$session"
-      if doppler secrets set "BW_SESSION=$session" --project personal-secrets --config prd > /dev/null 2>&1; then
-        echo "BW_SESSION saved to Doppler"
-      else
-        echo "Failed to save BW_SESSION to Doppler. Run 'doppler login' and try again." >&2
-      fi
-    fi
-  }
+  # Bitwarden が未ログインの場合のみ、Doppler の API 認証情報でログイン
+  login-bitwarden
 
 fi
 

--- a/home/bin/functions/bitwarden
+++ b/home/bin/functions/bitwarden
@@ -1,0 +1,28 @@
+#!/bin/zsh
+
+# Bitwarden が未ログインの場合のみ、Doppler の API 認証情報でログイン
+function login-bitwarden() {
+  local bw_status client_id client_secret
+  bw_status=$(bw status 2>/dev/null | jq -r '.status' 2>/dev/null)
+  if [[ "$bw_status" != "unauthenticated" ]]; then
+    return 0
+  fi
+
+  client_id=$(doppler secrets get BW_CLIENTID --plain --project personal-secrets --config prd 2>/dev/null)
+  client_secret=$(doppler secrets get BW_CLIENTSECRET --plain --project personal-secrets --config prd 2>/dev/null)
+  if [[ -z "$client_id" || -z "$client_secret" ]]; then
+    echo "Failed to get Bitwarden API credentials from Doppler." >&2
+    return 1
+  fi
+
+  BW_CLIENTID="$client_id" BW_CLIENTSECRET="$client_secret" bw login --apikey
+}
+
+# 端末ごとの Bitwarden ログインセッションを作成
+function unlock-bitwarden() {
+  local session
+  session=$(bw unlock --raw)
+  if [[ -n "$session" ]]; then
+    export BW_SESSION="$session"
+  fi
+}

--- a/home/bin/functions/kill-ssh-agent
+++ b/home/bin/functions/kill-ssh-agent
@@ -1,0 +1,6 @@
+#!/bin/zsh
+
+# ssh-agent を止める
+function kill-ssh-agent() {
+  pkill -f "socat.*TCP-LISTEN:${SSH_AGENT_LISTENING_PORT}"
+}


### PR DESCRIPTION
## Summary

- Doppler からの `BW_SESSION` 読み書きを廃止
- 未ログイン時だけ Bitwarden API 認証情報で CLI ログイン
- `unlock-bitwarden` で端末ごとにセッションを作成
- zsh 関数を `home/bin/functions` へ分離し、README に役割を追記

## Test

- `zsh -n`
- `shellcheck install.sh`
- zsh 関数の分離読み込みテスト
- `yui list --no-color`